### PR TITLE
希望添加手动重新计算的途径

### DIFF
--- a/dist/vue-pin.js
+++ b/dist/vue-pin.js
@@ -436,6 +436,7 @@ var Pin$1 = function () {
 Pin$1.directiveOptions = {
   inserted: function inserted(el, options) {
     Pin$1.create(el, options.value);
+    el.updatePin = Pin$1.create.bind(null, el, options.value);
   },
   componentUpdated: function componentUpdated(el, options) {
     setTimeout(function () {

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ import Pin from './src/Pin'
 Pin.directiveOptions = {
   inserted: function (el, options) {
     Pin.create(el, options.value)
+    el.updatePin = Pin.create.bind(null, el, options.value)
   },
   componentUpdated: function (el, options) {
     setTimeout(() => { Pin.create(el, options.value) }, 500)


### PR DESCRIPTION
自定义指令的钩子函数 `componentUpdated` 的更新是在组件及其子组件更新的时候调用。有一种情况
```
<div class="parent">
  <div class="pin" v-pin="{ containerSelector: '.parent' }"/>
  <div class="other"/>
</div>
```
当 `.other` 更新导致 `.parent` 组件高度更新的时候无法触发 `componentUpdated`，所以希望添加手动触发的方式。可以在外部直接调用更新。
谢谢~